### PR TITLE
Adding `Interval.size/2`

### DIFF
--- a/lib/interval.ex
+++ b/lib/interval.ex
@@ -26,18 +26,14 @@ defmodule Interval do
   in the interval.
 
   The endpoints are stored as an `t:Interval.Endpoint.t/0` or
-  the atom `:unbounded`.  
-
-  A special case exists for the empty interval,
-  which is represented by both `left` and `right` being
-  set to the atom `:empty`
+  the atom `:unbounded`.
 
   """
   @type t() :: %__MODULE__{
           # Left endpoint
-          left: :empty | :unbounded | Interval.Endpoint.t(),
+          left: :unbounded | Interval.Endpoint.t(),
           # Right  endpoint
-          right: :empty | :unbounded | Interval.Endpoint.t()
+          right: :unbounded | Interval.Endpoint.t()
         }
 
   @doc """
@@ -91,8 +87,6 @@ defmodule Interval do
   @doc """
   Normalize an `Interval` struct
   """
-  # lef and right endpoints set to :empty, special case for normalized empty interval
-  def normalize(%__MODULE__{left: :empty, right: :empty} = self), do: self
   # non-empty non-unbounded Interval:
   def normalize(%__MODULE__{left: %Endpoint{} = left, right: %Endpoint{} = right} = original) do
     left_point_impl = Point.impl_for(left.point)
@@ -117,16 +111,18 @@ defmodule Interval do
         raise "left > right which is invalid"
 
       # intervals given as either (p,p), [p,p) or (p,p]
-      # are all normalized to empty.
       # (If you want a single point in an interval, give it as [p,p])
+      # The (p,p) interval is already normalize form
       {_, :eq, false, false} ->
-        into_empty(original)
+        normalized_empty(original)
 
+      # [p,p) and (p,p] is normalized by taking the exlusive endpoint and
+      # setting it as both left and right
       {_, :eq, true, false} ->
-        into_empty(original)
+        normalized_empty(original)
 
       {_, :eq, false, true} ->
-        into_empty(original)
+        normalized_empty(original)
 
       # otherwise, if the point type is continuous, the the orignal
       # interval was already normalized form:
@@ -139,10 +135,12 @@ defmodule Interval do
 
       # if both bounds are exclusive, we also need to check for empty, because
       # we could still have an empty interval like (1,2)
+      # which is the same as (1,1) so we normalize by setting
+      # both endpoints to the same value.
       {:discrete, _, false, false} ->
         case Point.compare(Point.next(left.point), right.point) do
           :eq ->
-            into_empty(original)
+            normalized_empty(original)
 
           :lt ->
             %__MODULE__{original | left: normalize_left_endpoint(left)}
@@ -206,7 +204,15 @@ defmodule Interval do
   Is the interval empty?
 
   An empty interval is an interval that represents no points.
-  Any interval interval containing no points is considered empty.
+  Any interval containing no points is considered empty.
+
+  An unbounded interval is never empty.
+
+  For continuous points, the interval is empty when the left and
+  right points are identical, and the point is not included in the interval.
+
+  For discrete points, the interval is empty when the left and right point
+  isn't inclusive, and there are no points between the left and right point.
 
   ## Examples
 
@@ -220,8 +226,45 @@ defmodule Interval do
       false
 
   """
-  def empty?(%__MODULE__{left: :empty, right: :empty}), do: true
-  def empty?(%__MODULE__{}), do: false
+  def empty?(%__MODULE__{left: :unbounded}), do: false
+  def empty?(%__MODULE__{right: :unbounded}), do: false
+  # If properly normalized, all empty intervals have been normalized to the form
+  # `(zero, zero)` so we can match directly on that:
+  def empty?(%__MODULE__{
+        left: %{inclusive: false, point: p},
+        right: %{inclusive: false, point: p}
+      }),
+      do: true
+
+  # If the interval is not properly normalized, we don't want to give an
+  # incorrect answer, so we do the math to check if the interval is indeed empty:
+  def empty?(%__MODULE__{left: %Endpoint{} = left, right: %Endpoint{} = right}) do
+    compare = Point.compare(left.point, right.point)
+
+    cond do
+      # left and right is equal, then the interval is empty
+      # if the point is not included in the interval.
+      # We don't want to rely on normalized intervals in empty?/1
+      # in this function body, because if the interval was already normalized,
+      # we'd only have to check for the `(zero,zero)` interval.
+      # Therefore we must assume that the bounds could be incorrectly set to e.g. [p,p)
+      compare == :eq ->
+        not left.inclusive or not right.inclusive
+
+      # if the point type is discrete and both bounds are exclusive,
+      # then the interval could _also_ be empty if next(left) == right,
+      # because the interval would represent 0 points.
+      Point.type(left.point) == :discrete and not left.inclusive and not right.inclusive ->
+        :eq ==
+          left.point
+          |> Point.next()
+          |> Point.compare(right.point)
+
+      # If none of the above, then the interval is not empty
+      true ->
+        false
+    end
+  end
 
   @doc """
   Check if the interval is left-unbounded.
@@ -318,14 +361,6 @@ defmodule Interval do
   The returned value depends on the Point implementation used.
 
   - If the interval is unbounded, this function returns `nil`.
-  - If the inteval is empty, this function returns `nil`.
-
-  > #### Warning {: .warning}
-  > The reason for returning `nil` when the interval is empty, is that
-  > we do not currently know the point type of an empty interval, and cannot
-  > return a "zero" value for it.
-  > This might change in the future, where `size/2` will consistently return
-  > the "zero" value for the given point type.
 
   > #### Note {: .info}
   > The size is implemented as `right - left`, ignoring inclusive/exclusive bounds.
@@ -356,16 +391,17 @@ defmodule Interval do
   can be said to "contain" (aka. number of days)
 
   ### Examples
-        
-      # This interval is empty, so the reported size is nil
-      iex> size(new(left: 1, right: 1, bounds: "()"))
-      nil
-      
+
       iex> size(new(left: 1, right: 1, bounds: "[]"))
       1
 
       iex> size(new(left: 1, right: 3, bounds: "[)"))
       2
+
+      # Note that this interval will be normalized to an empty (0,0) interval
+      # but the math is still the same: `right - left` 
+      iex> size(new(left: 1, right: 2, bounds: "()"))
+      0
 
   ## For Continuous Intervals
 
@@ -377,18 +413,24 @@ defmodule Interval do
       # The size of the interval `[1.0, 5.0)` is also 4:
       iex> size(new(left: 1.0, right: 5.0, bounds: "[)"))
       4.0
-    
+
       # And likewise, so is the size of `[1.0, 5.0]` (note the bound change)
       iex> size(new(left: 1.0, right: 5.0, bounds: "[]"))
       4.0
-    
+
+      # Exactly one point contained in  this continuous interval,
+      # so technically not empty, but it also has zero  size.
+      iex> size(new(left: 1.0, right: 1.0, bounds: "[]"))
+      0.0
+
+      # Empty continuous interval
+      iex> size(new(left: 1.0, right: 1.0, bounds: "()"))
+      0.0
+
   """
   @spec size(t(), unit :: any()) :: any()
   def size(%__MODULE__{} = a, unit \\ nil) do
     cond do
-      empty?(a) ->
-        nil
-
       unbounded_left?(a) ->
         nil
 
@@ -829,7 +871,7 @@ defmodule Interval do
         # It should always be true, so no point in checking:
         true == strictly_left_of?(a, b) or strictly_right_of?(a, b)
 
-        into_empty(a)
+        normalized_empty(a)
     end
   end
 
@@ -899,7 +941,7 @@ defmodule Interval do
       # if A and B doesn't overlap,
       # then there can be no intersection
       not overlaps?(a, b) ->
-        into_empty(a)
+        normalized_empty(a)
 
       # otherwise, we can compute the intersection:
       true ->
@@ -969,7 +1011,21 @@ defmodule Interval do
   defp unpack_bounds("[)"), do: {:inclusive, :exclusive}
   defp unpack_bounds("(]"), do: {:exclusive, :inclusive}
 
-  defp into_empty(interval) do
-    %{interval | left: :empty, right: :empty}
+  defp normalized_empty(%__MODULE__{left: left, right: right} = a) do
+    point =
+      case {left, right} do
+        {%Endpoint{point: point}, _} ->
+          Point.zero(point)
+
+        {_, %Endpoint{point: point}} ->
+          Point.zero(point)
+
+        {:unbounded, :unbounded} ->
+          raise "cannot convert unbounded interval into empty interval"
+      end
+
+    endpoint = Endpoint.new(point, :exclusive)
+
+    %{a | left: endpoint, right: endpoint}
   end
 end

--- a/lib/interval/point.ex
+++ b/lib/interval/point.ex
@@ -105,7 +105,7 @@ defprotocol Interval.Point do
 
   The supported units are implementation specific.
   """
-  @spec subtract(t(), t()) :: any()
+  @spec subtract(t(), t(), unit :: any()) :: any()
   def subtract(a, b, unit \\ nil)
 
   @doc """
@@ -121,5 +121,14 @@ defprotocol Interval.Point do
   and the default uni of `subtract/3` must also be the
   default unit of `add/3`
   """
+  @spec add(t(), value :: any(), unit :: any()) :: t()
   def add(a, value_to_add, unit \\ nil)
+
+  @doc """
+  Returns the "zero" value for this point type.
+  This is used provide the point value used for
+  empty intervals.
+  """
+  @spec zero(t()) :: t()
+  def zero(a)
 end

--- a/lib/interval/point.ex
+++ b/lib/interval/point.ex
@@ -96,4 +96,30 @@ defprotocol Interval.Point do
   """
   @spec max(t(), t()) :: t()
   def max(a, b)
+
+  @doc """
+  subtract `b` from `a`, returning the value
+  in a unit that is relevant for the given point type.
+  An optional argument `unit` can be specified if the point type
+  has multiple units of relevance.
+
+  The supported units are implementation specific.
+  """
+  @spec subtract(t(), t()) :: any()
+  def subtract(a, b, unit \\ nil)
+
+  @doc """
+  Add `value_to_add` to `a`.
+  `value_to_add` is in the `unit` given as third argument.
+
+  The supported units are implementation specific,
+  however they should mirror the available units of `subtract/3`,
+  such that
+
+      iex> add(b, subtract(a, b)) == a
+
+  and the default uni of `subtract/3` must also be the
+  default unit of `add/3`
+  """
+  def add(a, value_to_add, unit \\ nil)
 end

--- a/lib/interval/point/date.ex
+++ b/lib/interval/point/date.ex
@@ -1,44 +1,44 @@
 if Application.get_env(:interval, Date, true) do
   defimpl Interval.Point, for: Date do
     @doc """
-      iex> compare(~D[2022-01-01], ~D[2022-01-01])
-      :eq
-      
-      iex> compare(~D[2022-01-01], ~D[2022-01-02])
-      :lt
+        iex> compare(~D[2022-01-01], ~D[2022-01-01])
+        :eq
+        
+        iex> compare(~D[2022-01-01], ~D[2022-01-02])
+        :lt
 
-      iex> compare(~D[2022-01-02], ~D[2022-01-01])
-      :gt
+        iex> compare(~D[2022-01-02], ~D[2022-01-01])
+        :gt
     """
     defdelegate compare(a, b), to: Date
 
     @doc """
-      iex> type(~D[2022-01-01])
-      :discrete
+        iex> type(~D[2022-01-01])
+        :discrete
     """
     def type(%Date{}), do: :discrete
 
     @doc """
-      iex> next(~D[2022-01-01])
-      ~D[2022-01-02]
+        iex> next(~D[2022-01-01])
+        ~D[2022-01-02]
     """
     def next(%Date{} = date), do: Date.add(date, 1)
 
     @doc """
-      iex> previous(~D[2022-01-01])
-      ~D[2021-12-31]
+        iex> previous(~D[2022-01-01])
+        ~D[2021-12-31]
     """
     def previous(%Date{} = date), do: Date.add(date, -1)
 
     @doc """
-      iex> Interval.Point.Date.min(~D[2022-01-01], ~D[2022-01-02])
-      ~D[2022-01-01]
+        iex> Interval.Point.Date.min(~D[2022-01-01], ~D[2022-01-02])
+        ~D[2022-01-01]
 
-      iex> Interval.Point.Date.min(~D[2022-01-01], ~D[2022-01-01])
-      ~D[2022-01-01]
+        iex> Interval.Point.Date.min(~D[2022-01-01], ~D[2022-01-01])
+        ~D[2022-01-01]
 
-      iex> Interval.Point.Date.min(~D[2022-01-02], ~D[2022-01-01])
-      ~D[2022-01-01]
+        iex> Interval.Point.Date.min(~D[2022-01-02], ~D[2022-01-01])
+        ~D[2022-01-01]
     """
     def min(a, b) do
       case Date.compare(a, b) do
@@ -49,14 +49,14 @@ if Application.get_env(:interval, Date, true) do
     end
 
     @doc """
-      iex> Interval.Point.Date.max(~D[2022-01-01], ~D[2022-01-02])
-      ~D[2022-01-02]
+        iex> Interval.Point.Date.max(~D[2022-01-01], ~D[2022-01-02])
+        ~D[2022-01-02]
 
-      iex> Interval.Point.Date.max(~D[2022-01-02], ~D[2022-01-02])
-      ~D[2022-01-02]
-      
-      iex> Interval.Point.Date.max(~D[2022-01-02], ~D[2022-01-01])
-      ~D[2022-01-02]
+        iex> Interval.Point.Date.max(~D[2022-01-02], ~D[2022-01-02])
+        ~D[2022-01-02]
+        
+        iex> Interval.Point.Date.max(~D[2022-01-02], ~D[2022-01-01])
+        ~D[2022-01-02]
     """
     def max(a, b) do
       case Date.compare(a, b) do
@@ -64,6 +64,22 @@ if Application.get_env(:interval, Date, true) do
         :eq -> a
         :gt -> a
       end
+    end
+
+    @doc """
+        iex> subtract(~D[2022-01-02], ~D[2022-01-01])
+        1
+    """
+    def subtract(a, b, _unit \\ nil) do
+      Date.diff(a, b)
+    end
+
+    @doc """
+        iex> add(~D[2022-01-02], 1)
+        ~D[2022-01-03]
+    """
+    def add(a, days, _unit \\ nil) do
+      Date.add(a, days)
     end
   end
 end

--- a/lib/interval/point/date.ex
+++ b/lib/interval/point/date.ex
@@ -81,5 +81,7 @@ if Application.get_env(:interval, Date, true) do
     def add(a, days, _unit \\ nil) do
       Date.add(a, days)
     end
+
+    def zero(_), do: ~D[0000-01-01]
   end
 end

--- a/lib/interval/point/date_time.ex
+++ b/lib/interval/point/date_time.ex
@@ -81,5 +81,7 @@ if Application.get_env(:interval, DateTime, true) do
     def add(a, value_to_add, unit \\ :second) do
       DateTime.add(a, value_to_add, unit)
     end
+
+    def zero(_), do: ~U[0000-01-01 00:00:00Z]
   end
 end

--- a/lib/interval/point/date_time.ex
+++ b/lib/interval/point/date_time.ex
@@ -1,44 +1,44 @@
 if Application.get_env(:interval, DateTime, true) do
   defimpl Interval.Point, for: DateTime do
     @doc """
-      iex> compare(~U[2022-01-01 00:00:00Z], ~U[2022-01-01 00:00:00Z])
-      :eq
-      
-      iex> compare(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
-      :lt
+        iex> compare(~U[2022-01-01 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        :eq
+        
+        iex> compare(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
+        :lt
 
-      iex> compare(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
-      :gt
+        iex> compare(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        :gt
     """
     defdelegate compare(a, b), to: DateTime
 
     @doc """
-      iex> type(~U[2022-01-01 00:00:00Z])
-      :continuous
+        iex> type(~U[2022-01-01 00:00:00Z])
+        :continuous
     """
     def type(%DateTime{}), do: :continuous
 
     @doc """
-      iex> next(~U[2022-01-01 00:00:00Z])
-      ~U[2022-01-01 00:00:00Z]
+        iex> next(~U[2022-01-01 00:00:00Z])
+        ~U[2022-01-01 00:00:00Z]
     """
     def next(%DateTime{} = a), do: a
 
     @doc """
-      iex> previous(~U[2022-01-01 00:00:00Z])
-      ~U[2022-01-01 00:00:00Z]
+        iex> previous(~U[2022-01-01 00:00:00Z])
+        ~U[2022-01-01 00:00:00Z]
     """
     def previous(%DateTime{} = a), do: a
 
     @doc """
-      iex> Interval.Point.DateTime.min(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
-      ~U[2022-01-01 00:00:00Z]
+        iex> Interval.Point.DateTime.min(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
+        ~U[2022-01-01 00:00:00Z]
 
-      iex> Interval.Point.DateTime.min(~U[2022-01-01 00:00:00Z], ~U[2022-01-01 00:00:00Z])
-      ~U[2022-01-01 00:00:00Z]
-      
-      iex> Interval.Point.DateTime.min(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
-      ~U[2022-01-01 00:00:00Z]
+        iex> Interval.Point.DateTime.min(~U[2022-01-01 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        ~U[2022-01-01 00:00:00Z]
+        
+        iex> Interval.Point.DateTime.min(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        ~U[2022-01-01 00:00:00Z]
     """
     def min(a, b) do
       case DateTime.compare(a, b) do
@@ -49,14 +49,14 @@ if Application.get_env(:interval, DateTime, true) do
     end
 
     @doc """
-      iex> Interval.Point.DateTime.max(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
-      ~U[2022-01-02 00:00:00Z]
+        iex> Interval.Point.DateTime.max(~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])
+        ~U[2022-01-02 00:00:00Z]
 
-      iex> Interval.Point.DateTime.max(~U[2022-01-02 00:00:00Z], ~U[2022-01-02 00:00:00Z])
-      ~U[2022-01-02 00:00:00Z]
-      
-      iex> Interval.Point.DateTime.max(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
-      ~U[2022-01-02 00:00:00Z]
+        iex> Interval.Point.DateTime.max(~U[2022-01-02 00:00:00Z], ~U[2022-01-02 00:00:00Z])
+        ~U[2022-01-02 00:00:00Z]
+        
+        iex> Interval.Point.DateTime.max(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        ~U[2022-01-02 00:00:00Z]
     """
     def max(a, b) do
       case DateTime.compare(a, b) do
@@ -64,6 +64,22 @@ if Application.get_env(:interval, DateTime, true) do
         :eq -> a
         :gt -> a
       end
+    end
+
+    @doc """
+        iex> subtract(~U[2022-01-02 00:00:00Z], ~U[2022-01-01 00:00:00Z])
+        86400
+    """
+    def subtract(a, b, unit \\ :second) do
+      DateTime.diff(a, b, unit)
+    end
+
+    @doc """
+        iex> add(~U[2022-01-01 00:00:00Z], 86400)
+        ~U[2022-01-02 00:00:00Z]
+    """
+    def add(a, value_to_add, unit \\ :second) do
+      DateTime.add(a, value_to_add, unit)
     end
   end
 end

--- a/lib/interval/point/float.ex
+++ b/lib/interval/point/float.ex
@@ -1,47 +1,63 @@
 if Application.get_env(:interval, Float, true) do
   defimpl Interval.Point, for: Float do
     @doc """
-      iex> compare(1.0, 1.0)
-      :eq
-      
-      iex> compare(1.0, 2.0)
-      :lt
+        iex> compare(1.0, 1.0)
+        :eq
+        
+        iex> compare(1.0, 2.0)
+        :lt
 
-      iex> compare(2.0, 1.0)
-      :gt
+        iex> compare(2.0, 1.0)
+        :gt
     """
     def compare(a, a) when is_float(a), do: :eq
     def compare(a, b) when is_float(a) and is_float(b) and a > b, do: :gt
     def compare(a, b) when is_float(a) and is_float(b) and a < b, do: :lt
 
     @doc """
-      iex> type(1.0)
-      :continuous
+        iex> type(1.0)
+        :continuous
     """
     def type(a) when is_float(a), do: :continuous
 
     @doc """
-      iex> 1.0 |> next()
-      1.0
+        iex> 1.0 |> next()
+        1.0
     """
     def next(a) when is_float(a), do: a
 
     @doc """
-      iex> 3.0 |> previous()
-      3.0
+        iex> 3.0 |> previous()
+        3.0
     """
     def previous(a) when is_float(a), do: a
 
     @doc """
-      iex> Interval.Point.Float.min(1, 2)
-      1
+        iex> Interval.Point.Float.min(1, 2)
+        1
     """
     defdelegate min(a, b), to: Kernel
 
     @doc """
-      iex> Interval.Point.Float.max(1, 2)
-      2
+        iex> Interval.Point.Float.max(1, 2)
+        2
     """
     defdelegate max(a, b), to: Kernel
+
+    @doc """
+        iex> subtract(3.0, 1.0)
+        2.0
+    """
+    def subtract(a, b, _unit \\ nil) do
+      a - b
+    end
+
+    @doc """
+        iex> add(1.0, 2.0)
+        3.0
+    """
+    def add(a, value, _unit \\ nil) do
+      a + value
+    end
   end
 end

--- a/lib/interval/point/float.ex
+++ b/lib/interval/point/float.ex
@@ -59,5 +59,7 @@ if Application.get_env(:interval, Float, true) do
     def add(a, value, _unit \\ nil) do
       a + value
     end
+
+    def zero(_), do: 0.0
   end
 end

--- a/lib/interval/point/integer.ex
+++ b/lib/interval/point/integer.ex
@@ -59,5 +59,7 @@ if Application.get_env(:interval, Integer, true) do
     def add(a, value, _unit \\ nil) do
       a + value
     end
+
+    def zero(_), do: 0
   end
 end

--- a/lib/interval/point/integer.ex
+++ b/lib/interval/point/integer.ex
@@ -1,47 +1,63 @@
 if Application.get_env(:interval, Integer, true) do
   defimpl Interval.Point, for: Integer do
     @doc """
-      iex> compare(1, 1)
-      :eq
-      
-      iex> compare(1, 2)
-      :lt
+        iex> compare(1, 1)
+        :eq
+        
+        iex> compare(1, 2)
+        :lt
 
-      iex> compare(2, 1)
-      :gt
+        iex> compare(2, 1)
+        :gt
     """
     def compare(a, a) when is_integer(a), do: :eq
     def compare(a, b) when is_integer(a) and is_integer(b) and a > b, do: :gt
     def compare(a, b) when is_integer(a) and is_integer(b) and a < b, do: :lt
 
     @doc """
-      iex> type(1)
-      :discrete
+        iex> type(1)
+        :discrete
     """
     def type(a) when is_integer(a), do: :discrete
 
     @doc """
-      iex> 1 |> next() |> next()
-      3
+        iex> 1 |> next() |> next()
+        3
     """
     def next(a) when is_integer(a), do: a + 1
 
     @doc """
-      iex> 3 |> previous() |> previous()
-      1
+        iex> 3 |> previous() |> previous()
+        1
     """
     def previous(a) when is_integer(a), do: a - 1
 
     @doc """
-      iex> Interval.Point.Integer.min(1, 2)
-      1
+        iex> Interval.Point.Integer.min(1, 2)
+        1
     """
     defdelegate min(a, b), to: Kernel
 
     @doc """
-      iex> Interval.Point.Integer.max(1, 2)
-      2
+        iex> Interval.Point.Integer.max(1, 2)
+        2
     """
     defdelegate max(a, b), to: Kernel
+
+    @doc """
+        iex> subtract(3, 1)
+        2
+    """
+    def subtract(a, b, _unit \\ nil) do
+      a - b
+    end
+
+    @doc """
+        iex> add(1, 2)
+        3
+    """
+    def add(a, value, _unit \\ nil) do
+      a + value
+    end
   end
 end

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -86,6 +86,21 @@ defmodule IntervalTest do
     assert Interval.empty?(inter(1, 2, "()"))
     # but (1,3) should be non-empty because 2 is in the interval
     refute Interval.empty?(inter(1, 3, "()"))
+
+    # Check that even non-normalized intervals correctly indicates empty
+    non_normalized_1 = %Interval{
+      left: %Endpoint{inclusive: false, point: 1},
+      right: %Endpoint{inclusive: false, point: 2}
+    }
+
+    assert Interval.empty?(non_normalized_1)
+
+    non_normalized_2 = %Interval{
+      left: %Endpoint{inclusive: false, point: 1},
+      right: %Endpoint{inclusive: true, point: 1}
+    }
+
+    assert Interval.empty?(non_normalized_2)
   end
 
   test "inclusive_left?/1" do

--- a/test/point_test.exs
+++ b/test/point_test.exs
@@ -16,4 +16,14 @@ defmodule IntervalPointTest do
     assert Interval.Point.max(1, 2) === 2
     assert Interval.Point.max(1.0, 2.0) === 2.0
   end
+
+  test "subtract/3" do
+    assert Interval.Point.subtract(3, 2) === 1
+    assert Interval.Point.subtract(3.0, 2.0) === 1.0
+  end
+
+  test "add/3" do
+    assert Interval.Point.add(2, 1) === 3
+    assert Interval.Point.add(2.0, 1.0) === 3.0
+  end
 end


### PR DESCRIPTION
Also adding:

- `Interval.Point.subtract/3`
- `Interval.Point.add/2`

~~Currently, `size/2` is reporting empty intervals as `nil` size, because we don't know what point type the interval is, because we represent an empty interval as `left: :empty, right: :empty`.~~

An empty interval is now represented by the interval `(zero, zero)` where `zero` is a value
that each `Point` implementation must provide.

The properties of the old empty interval still holds. An empty interval is exactly equal to another empty interval (within the same point type, ofc)
But the underlying representation is more elegant.

This has allowed me to implement `size/2` such that an empty interval works the same as a non-empty interval.

The "cost" is that an `Interval.Point` must now provide a `zero/1` function that returns some "zero" value for that type.