### PR TITLE
Adding Decimal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Builtin `Jason.Encoder` support.
 - `Interval.__using__` option `jason_encoder` for including encoder. Defaults to `true`.
 - `Interval.to_map/1` to convert an Interval struct to a map suitible for JSON and similar serialization.
+- `Interval.Decimal` for `Decimal` support.
 
 ### Changed
 

--- a/lib/interval.ex
+++ b/lib/interval.ex
@@ -1205,14 +1205,16 @@ defmodule Interval do
     end
   end
 
-  # Pick the exclusive endpoint if it exists, else pick `a`
+  # Pick the exclusive endpoint if it exists
   defp pick_exclusive({:exclusive, _} = a, _), do: a
   defp pick_exclusive(_, {:exclusive, _} = b), do: b
+  defp pick_exclusive(a, b) when a < b, do: b
   defp pick_exclusive(a, _b), do: a
 
-  # Pick the inclusive endpoint if it exists, else pick `a`
+  # Pick the inclusive endpoint if it exists
   defp pick_inclusive({:inclusive, _} = a, _), do: a
   defp pick_inclusive(_, {:inclusive, _} = b), do: b
+  defp pick_inclusive(a, b) when a < b, do: b
   defp pick_inclusive(a, _b), do: a
 
   # Pick the left point of a union from two left points
@@ -1377,12 +1379,12 @@ defmodule Interval do
       end
   """
   defmacro __using__(opts) do
-    type = Keyword.fetch!(opts, :type)
-    discrete = Keyword.get(opts, :discrete, false)
-    jason_encoder = Keyword.get(opts, :jason_encoder, true)
-
     quote location: :keep,
-          bind_quoted: [jason_encoder: jason_encoder, type: type, discrete: discrete] do
+          bind_quoted: [
+            type: Keyword.fetch!(opts, :type),
+            discrete: Keyword.get(opts, :discrete, false),
+            jason_encoder: Keyword.get(opts, :jason_encoder, true)
+          ] do
       @moduledoc """
       Represents a #{if discrete, do: "discrete", else: "continuous"}
       interval containing `#{type}`

--- a/lib/interval/decimal.ex
+++ b/lib/interval/decimal.ex
@@ -1,0 +1,24 @@
+if Application.get_env(:interval, Interval.Decimal, true) and Code.ensure_loaded?(Decimal) do
+  defmodule Interval.Decimal do
+    @moduledoc false
+
+    use Interval, type: Decimal, discrete: false
+
+    if Code.ensure_loaded?(Interval.Support.Ecto) do
+      use Interval.Support.Ecto, ecto_type: :numrange
+    end
+
+    def point_valid?(a), do: is_struct(a, Decimal)
+
+    def size(%__MODULE__{left: {_, a}, right: {_, b}}), do: Decimal.sub(b, a)
+    def size(%__MODULE__{left: :empty, right: :empty}), do: Decimal.new(0)
+    def size(%__MODULE__{left: :unbounded}), do: nil
+    def size(%__MODULE__{right: :unbounded}), do: nil
+
+    def point_compare(a, b) when is_struct(a, Decimal) and is_struct(b, Decimal) do
+      Decimal.compare(a, b)
+    end
+
+    def point_step(a, _n) when is_struct(a, Decimal), do: nil
+  end
+end

--- a/lib/interval/intervalable.ex
+++ b/lib/interval/intervalable.ex
@@ -47,3 +47,9 @@ if Application.get_env(:interval, Interval.DateTime, true) do
     def infer_implementation(value) when is_struct(value, DateTime), do: Interval.DateTime
   end
 end
+
+if Application.get_env(:interval, Interval.Decimal, true) do
+  defimpl Interval.Intervalable, for: Decimal do
+    def infer_implementation(value) when is_struct(value, Decimal), do: Interval.Decimal
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule Interval.MixProject do
       {:ecto, ">= 3.4.3 and < 4.0.0", only: [:test, :dev], optional: true},
       {:postgrex, "~> 0.14", only: [:test, :dev], optional: true},
       {:jason, "~> 1.4", only: [:test, :dev], optional: true},
+      {:decimal, "~> 2.0", only: [:test, :dev], optional: true},
       {:stream_data, "~> 0.5", only: [:test, :dev], runtime: false},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},

--- a/test/builtin_test.exs
+++ b/test/builtin_test.exs
@@ -6,6 +6,7 @@ defmodule Interval.BuiltinTest do
   doctest Interval.Date, import: true
   doctest Interval.Float, import: true
   doctest Interval.DateTime, import: true
+  doctest Interval.Decimal, import: true
 
   test "Interval.Intervalable" do
     assert Interval.new(left: 1)
@@ -25,6 +26,24 @@ defmodule Interval.BuiltinTest do
       assert 4 === Interval.Integer.point_step(2, 2)
     end
 
+    test "size/1" do
+      assert 0 ===
+               Interval.Integer.new(left: 1, right: 1)
+               |> Interval.size()
+
+      assert 1 ===
+               Interval.Integer.new(left: 1, right: 2)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Integer.new(left: 1, right: nil)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Integer.new(left: nil, right: 2)
+               |> Interval.size()
+    end
+
     test "Interval.Intervalable" do
       assert Interval.Integer.new(left: 0, right: 1) ===
                Interval.new(left: 0, right: 1)
@@ -36,6 +55,24 @@ defmodule Interval.BuiltinTest do
       assert ~D[2022-01-03] === Interval.Date.point_step(~D[2022-01-01], 2)
     end
 
+    test "size/1" do
+      assert 0 ===
+               Interval.Date.new(left: ~D[2022-01-01], right: ~D[2022-01-01])
+               |> Interval.size()
+
+      assert 1 ===
+               Interval.Date.new(left: ~D[2022-01-01], right: ~D[2022-01-02])
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Date.new(left: ~D[2022-01-01], right: nil)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Date.new(left: nil, right: ~D[2022-01-02])
+               |> Interval.size()
+    end
+
     test "Interval.Intervalable" do
       assert Interval.Date.new(left: ~D[2022-01-01], right: ~D[2022-01-02]) ===
                Interval.new(left: ~D[2022-01-01], right: ~D[2022-01-02])
@@ -45,6 +82,24 @@ defmodule Interval.BuiltinTest do
   describe "Float" do
     test "point_step/2" do
       assert nil === Interval.Float.point_step(2.0, 2)
+    end
+
+    test "size/1" do
+      assert 0.0 ===
+               Interval.Float.new(left: 1.0, right: 1.0)
+               |> Interval.size()
+
+      assert 1.0 ===
+               Interval.Float.new(left: 1.0, right: 2.0)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Float.new(left: 1.0, right: nil)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Float.new(left: nil, right: 2.0)
+               |> Interval.size()
     end
 
     test "Interval.Intervalable" do
@@ -64,6 +119,45 @@ defmodule Interval.BuiltinTest do
                right: ~U[2022-01-02 00:00:00Z]
              ) ===
                Interval.new(left: ~U[2022-01-01 00:00:00Z], right: ~U[2022-01-02 00:00:00Z])
+    end
+  end
+
+  describe "Decimal" do
+    test "point_step/2" do
+      assert nil === Interval.Decimal.point_step(Decimal.new(1), 2)
+    end
+
+    test "discrete?/1" do
+      refute Interval.Decimal.discrete?()
+    end
+
+    test "size/1" do
+      assert Decimal.new(0) ===
+               Interval.Decimal.new(left: Decimal.new(1), right: Decimal.new(1))
+               |> Interval.size()
+
+      assert Decimal.new(1) ===
+               Interval.Decimal.new(left: Decimal.new(1), right: Decimal.new(2))
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Decimal.new(left: Decimal.new(1), right: nil)
+               |> Interval.size()
+
+      assert nil ===
+               Interval.Decimal.new(left: nil, right: Decimal.new(2))
+               |> Interval.size()
+    end
+
+    test "Interval.Intervalable" do
+      assert Interval.Decimal.new(
+               left: Decimal.new(1),
+               right: Decimal.new(2)
+             ) ===
+               Interval.new(
+                 left: Decimal.new(1),
+                 right: Decimal.new(2)
+               )
     end
   end
 end

--- a/test/decimal_interval_property_test.exs
+++ b/test/decimal_interval_property_test.exs
@@ -1,0 +1,124 @@
+defmodule Interval.DecimalIntervalPropertyTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  property "overlaps?/2 is commutative" do
+    check all(
+            a <- Helper.decimal_interval(),
+            b <- Helper.decimal_interval()
+          ) do
+      assert Interval.overlaps?(a, b) === Interval.overlaps?(b, a)
+    end
+  end
+
+  property "union/2 is commutative" do
+    check all(
+            a <- Helper.decimal_interval(),
+            b <- Helper.decimal_interval()
+          ) do
+      assert Interval.union(a, b) === Interval.union(b, a)
+    end
+  end
+
+  property "intersection/2 is commutative" do
+    check all(
+            a <- Helper.decimal_interval(),
+            b <- Helper.decimal_interval()
+          ) do
+      assert Interval.intersection(a, b) === Interval.intersection(b, a)
+    end
+  end
+
+  property "intersection/2's relationship with contains?/2" do
+    check all(
+            a <- Helper.decimal_interval(),
+            b <- Helper.decimal_interval()
+          ) do
+      intersection = Interval.intersection(a, b)
+
+      cond do
+        # when A contains B (or later, B contains A) then the
+        # intersection between the two intervals will be the contained one.
+        Interval.contains?(a, b) ->
+          assert intersection === b
+
+        Interval.contains?(b, a) ->
+          assert intersection === a
+
+        true ->
+          assert Interval.intersection(a, b) === Interval.intersection(b, a)
+      end
+    end
+  end
+
+  property "contains?/2" do
+    check all(
+            a <- Helper.decimal_interval(),
+            b <- Helper.decimal_interval()
+          ) do
+      cond do
+        Interval.empty?(a) or Interval.empty?(b) ->
+          refute Interval.contains?(a, b)
+          refute Interval.contains?(b, a)
+
+        a == b ->
+          assert Interval.contains?(a, b)
+          assert Interval.contains?(b, a)
+
+        a != b ->
+          a_contains_b = Interval.contains?(a, b)
+          b_contains_a = Interval.contains?(b, a)
+
+          assert(
+            (a_contains_b and not b_contains_a) or
+              (b_contains_a and not a_contains_b) or
+              (not a_contains_b and not b_contains_a)
+          )
+      end
+    end
+  end
+
+  property "strictly_left_of?/2 and strictly_right_of?/2 relationship" do
+    check all(
+            a <- Helper.decimal_interval(empty: false),
+            b <- Helper.decimal_interval(empty: false)
+          ) do
+      if Interval.overlaps?(a, b) do
+        refute Interval.strictly_left_of?(a, b)
+        refute Interval.strictly_right_of?(a, b)
+      else
+        if Interval.strictly_left_of?(a, b) do
+          refute Interval.overlaps?(a, b)
+          refute Interval.strictly_right_of?(a, b)
+        end
+
+        if Interval.strictly_right_of?(a, b) do
+          refute Interval.overlaps?(a, b)
+          refute Interval.strictly_left_of?(a, b)
+        end
+      end
+    end
+  end
+
+  property "adjacent_left_of?/2 and adjacent_right_of?/2 relationship" do
+    check all(
+            a <- Helper.decimal_interval(empty: false),
+            b <- Helper.decimal_interval(empty: false)
+          ) do
+      if Interval.overlaps?(a, b) do
+        refute Interval.adjacent_left_of?(a, b)
+        refute Interval.adjacent_right_of?(a, b)
+      else
+        if Interval.adjacent_left_of?(a, b) do
+          refute Interval.overlaps?(a, b)
+          refute Interval.adjacent_right_of?(a, b)
+        end
+
+        if Interval.adjacent_right_of?(a, b) do
+          refute Interval.overlaps?(a, b)
+          refute Interval.adjacent_left_of?(a, b)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds built in support for the [`Decimal`](https://hexdocs.pm/decimal/2.0.0/Decimal.html) library.

Adding support for Decimal also revealed a minor issue with how points in an intersection is picked (did not affect correctness though)

