### PR TITLE
Fix optional deps should not specify `only:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The optional dependencies was also specified as test and dev only, which
+  is not what we want. We want them optional, but all environments.
+
 ### Security
 
 ## [v0.3.2] - 2022-11-22

--- a/mix.exs
+++ b/mix.exs
@@ -80,10 +80,10 @@ defmodule Interval.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ecto, ">= 3.4.3 and < 4.0.0", only: [:test, :dev], optional: true},
-      {:postgrex, "~> 0.14", only: [:test, :dev], optional: true},
-      {:jason, "~> 1.4", only: [:test, :dev], optional: true},
-      {:decimal, "~> 2.0", only: [:test, :dev], optional: true},
+      {:ecto, ">= 3.4.3 and < 4.0.0", optional: true},
+      {:postgrex, "~> 0.14", optional: true},
+      {:jason, "~> 1.4", optional: true},
+      {:decimal, "~> 2.0", optional: true},
       {:stream_data, "~> 0.5", only: [:test, :dev], runtime: false},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},


### PR DESCRIPTION
This might be related to the issue in #19 
or at least create an inverse problem of that issue, where a project
that uses Ecto and Postgrex might not be picked up by Interval.