### PR TITLE
Adding support for intervals of `NaiveDateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Inspect` protocol implementation for all intervals created with `use Interval`
   (which includes all builtin types) so they now look like `#Interval.Float<[1.0, 3.0)>`
   instead of `%Interval.Float{left: {:inclusive, 1.0}, right: {:exclusive, 3.0}}`
+- Support for intervals of `NaiveDateTime`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ end
 - `Interval.Decimal` A continuous interval between two `Decimal` structs.
 - `Interval.Date` A discrete interval between two `Date` structs.
 - `Interval.DateTime` A continuous interval between two `DateTime` structs.
+- `Interval.NaiveDateTime` A continuous interval between two `NaiveDateTime` structs.
 
 ## Ecto & Postgres `range` types
 

--- a/lib/interval.ex
+++ b/lib/interval.ex
@@ -29,6 +29,7 @@ defmodule Interval do
       - `Float`
       - `Date`
       - `DateTime`
+      - `NaiveDateTime`
       - `Decimal`
   - Also implements
     - `Ecto.Type`
@@ -74,6 +75,7 @@ defmodule Interval do
 
   - `Interval.Date` containing points of type `Date`
   - `Interval.DateTime` containing points of type `DateTime`
+  - `Interval.NaiveDateTime` containing points of type `NaiveDateTime`
   - `Interval.Float` containing points of type `Float`
   - `Interval.Integer` containing points of type `Integer`
   - `Interval.Decimal` containing points of type `Decimal` (See https://hexdocs.pm/decimal/2.0.0)

--- a/lib/interval/intervalable.ex
+++ b/lib/interval/intervalable.ex
@@ -48,6 +48,13 @@ if Application.get_env(:interval, Interval.DateTime, true) do
   end
 end
 
+if Application.get_env(:interval, Interval.NaiveDateTime, true) do
+  defimpl Interval.Intervalable, for: NaiveDateTime do
+    def infer_implementation(value) when is_struct(value, NaiveDateTime),
+      do: Interval.NaiveDateTime
+  end
+end
+
 if Application.get_env(:interval, Interval.Decimal, true) do
   defimpl Interval.Intervalable, for: Decimal do
     def infer_implementation(value) when is_struct(value, Decimal), do: Interval.Decimal

--- a/lib/interval/naive_date_time.ex
+++ b/lib/interval/naive_date_time.ex
@@ -1,0 +1,26 @@
+if Application.get_env(:interval, Interval.NaiveDateTime, true) do
+  defmodule Interval.NaiveDateTime do
+    @moduledoc false
+
+    use Interval, type: NaiveDateTime, discrete: false
+
+    if Interval.Support.EctoType.supported?() do
+      use Interval.Support.EctoType, ecto_type: :tstzrange
+    end
+
+    @spec size(t()) :: integer() | nil
+    def size(%__MODULE__{right: :unbounded}), do: nil
+    def size(%__MODULE__{left: :unbounded}), do: nil
+    def size(%__MODULE__{left: :empty, right: :empty}), do: 0.0
+    def size(%__MODULE__{left: {_, a}, right: {_, b}}), do: NaiveDateTime.diff(b, a)
+
+    @spec point_valid?(NaiveDateTime.t()) :: boolean()
+    def point_valid?(a), do: is_struct(a, NaiveDateTime)
+
+    @spec point_compare(NaiveDateTime.t(), NaiveDateTime.t()) :: :lt | :eq | :gt
+    defdelegate point_compare(a, b), to: NaiveDateTime, as: :compare
+
+    @spec point_step(NaiveDateTime.t(), any()) :: nil
+    def point_step(%NaiveDateTime{}, _n), do: nil
+  end
+end

--- a/test/builtin_test.exs
+++ b/test/builtin_test.exs
@@ -122,6 +122,20 @@ defmodule Interval.BuiltinTest do
     end
   end
 
+  describe "NaiveDateTime" do
+    test "point_step/2" do
+      assert nil === Interval.NaiveDateTime.point_step(~N[2022-01-01 00:00:00], 2)
+    end
+
+    test "Interval.Intervalable" do
+      assert Interval.NaiveDateTime.new(
+               left: ~N[2022-01-01 00:00:00],
+               right: ~N[2022-01-02 00:00:00]
+             ) ===
+               Interval.new(left: ~N[2022-01-01 00:00:00], right: ~N[2022-01-02 00:00:00])
+    end
+  end
+
   describe "Decimal" do
     test "point_step/2" do
       assert nil === Interval.Decimal.point_step(Decimal.new(1), 2)

--- a/test/inspect_test.exs
+++ b/test/inspect_test.exs
@@ -24,6 +24,15 @@ defmodule Interval.InspectTest do
     assert str === "#Interval.DateTime<[~U[2022-01-01 00:00:00Z], ~U[2022-01-02 00:00:00Z])>"
   end
 
+  test "NaiveDateTime" do
+    str =
+      [left: ~N(2022-01-01T00:00:00), right: ~N(2022-01-02T00:00:00)]
+      |> Interval.NaiveDateTime.new()
+      |> inspect()
+
+    assert str === "#Interval.NaiveDateTime<[~N[2022-01-01 00:00:00], ~N[2022-01-02 00:00:00])>"
+  end
+
   test "Decimal" do
     str =
       [left: Decimal.new(1), right: Decimal.new(2)]
@@ -40,5 +49,14 @@ defmodule Interval.InspectTest do
       |> inspect()
 
     assert str === "#Interval.Integer<[1, 2)>"
+  end
+
+  test "Float" do
+    str =
+      [left: 1.0, right: 2.0]
+      |> Interval.Float.new()
+      |> inspect()
+
+    assert str === "#Interval.Float<[1.0, 2.0)>"
   end
 end

--- a/test/interval_test.exs
+++ b/test/interval_test.exs
@@ -87,6 +87,19 @@ defmodule Interval.IntervalTest do
                  right: ~U[2021-02-01 00:00:00Z]
                )
              )
+
+    assert 0.0 === Interval.size(Interval.NaiveDateTime.new(left: :empty, right: :empty))
+    assert nil === Interval.size(Interval.NaiveDateTime.new(left: ~N[2021-01-01 00:00:00]))
+    assert nil === Interval.size(Interval.NaiveDateTime.new(right: ~N[2021-01-01 00:00:00]))
+    assert nil === Interval.size(Interval.NaiveDateTime.new())
+
+    assert 31 * 86_400 ===
+             Interval.size(
+               Interval.NaiveDateTime.new(
+                 left: ~N[2021-01-01 00:00:00],
+                 right: ~N[2021-02-01 00:00:00]
+               )
+             )
   end
 
   test "empty?/1" do

--- a/test/support/ecto_test.exs
+++ b/test/support/ecto_test.exs
@@ -84,6 +84,7 @@ defmodule Interval.Support.EctoTypeTest do
 
     assert empty == to_interval_to_range(empty, Interval.Date)
     assert empty == to_interval_to_range(empty, Interval.DateTime)
+    assert empty == to_interval_to_range(empty, Interval.NaiveDateTime)
     assert empty == to_interval_to_range(empty, Interval.Float)
     assert empty == to_interval_to_range(empty, Interval.Integer)
   end
@@ -93,6 +94,7 @@ defmodule Interval.Support.EctoTypeTest do
 
     assert unbound == to_interval_to_range(unbound, Interval.Date)
     assert unbound == to_interval_to_range(unbound, Interval.DateTime)
+    assert unbound == to_interval_to_range(unbound, Interval.NaiveDateTime)
     assert unbound == to_interval_to_range(unbound, Interval.Float)
     assert unbound == to_interval_to_range(unbound, Interval.Integer)
   end


### PR DESCRIPTION
Adding `NaiveDateTime` was almost just a copy/paste of the `Interval.DateTime` module.
